### PR TITLE
ignore py repl tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This is a precommit hook that applies a patched version of prettier that
-recognizes the `py-script` and `py-config` tags and does not reformat their
+recognizes the `py-script`, `py-config` and `py-repl` tags and does not reformat their
 contents. The patch that has been applied to prettier is as follows:
 
 ```patch
@@ -11,6 +11,7 @@ contents. The patch that has been applied to prettier is as follows:
      node.type === "element" &&
 -    (node.fullName === "script" ||
 +    (node.fullName === "py-script" ||
++    (node.fullName === "py-repl" ||
 +      node.fullName === "py-config" ||
 +      node.fullName === "script" ||
        node.fullName === "style" ||

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -32536,7 +32536,7 @@ function isTextLikeNode(node) {
   return node.type === "text" || node.type === "comment";
 }
 function isScriptLikeTag(node) {
-  return node.type === "element" && (node.fullName === "py-script" || node.fullName === "py-config" || node.fullName === "script" || node.fullName === "style" || node.fullName === "svg:style" || is_unknown_namespace_default(node) && (node.name === "script" || node.name === "style"));
+  return node.type === "element" && (node.fullName === "py-script" || node.fullName === "py-repl" || node.fullName === "py-config" || node.fullName === "script" || node.fullName === "style" || node.fullName === "svg:style" || is_unknown_namespace_default(node) && (node.name === "script" || node.name === "style"));
 }
 function canHaveInterpolation(node) {
   return node.children && !isScriptLikeTag(node);


### PR DESCRIPTION
Currently py-repl tags are reformatted which results in errors, i.e. for the pandas example, if the repl gets executed:
![image](https://user-images.githubusercontent.com/31857876/227706476-2cc111a8-b1c7-4da1-92d3-9de455a7f72d.png)

This fix mitigates this by ignoring `py-repl` tags aswell.